### PR TITLE
Redoing setup a bit to make it more flexible for AL9 vs SL7. If it's …

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -26,3 +26,4 @@ include_directories(${ROOT_INCLUDE_DIRS})
 
 # add sub directories
 add_subdirectory(src)
+add_subdirectory(app)

--- a/app/CMakeLists.txt
+++ b/app/CMakeLists.txt
@@ -1,0 +1,13 @@
+add_executable(run_test run_test.C)
+
+target_link_libraries(run_test
+ PRIVATE
+  E4Track 
+  ${ROOT_LIBRARIES}
+)
+target_include_directories(
+  run_test PRIVATE 
+  ${CMAKE_SOURCE_DIR}
+)
+
+install(TARGETS run_test )

--- a/app/run_test.C
+++ b/app/run_test.C
@@ -1,4 +1,4 @@
-#include "./src/Hypfit.h"
+#include "src/Hypfit.h"
 
 void run_test(){
 
@@ -16,4 +16,9 @@ void run_test(){
   cout << "proton KE(rr = 30 cm): " << proton_dedx -> KEFromRangeSpline(30.) << endl;
   cout << "test_p_likelihood_KE: " << test_p_likelihood_KE << endl;
   cout << "test_p_gaus_KE: " << test_p_gaus_KE << endl;
+}
+
+int main() {
+  run_test();
+  return 0;
 }

--- a/setup.sh
+++ b/setup.sh
@@ -2,12 +2,33 @@ export E4Track_WD=`pwd`
 export E4Track_LIB_PATH=$E4Track_WD/lib/
 mkdir -p $E4Track_LIB_PATH
 
-#### Setup Directories ####
-if [[ $HOSTNAME == *"dunegpvm"*"fnal.gov" ]]; then
-    source /cvmfs/fermilab.opensciencegrid.org/packages/common/setup-env.sh ## -- For Alma 9
-    source /cvmfs/larsoft.opensciencegrid.org/spack-packages/setup-env.sh
-    spack load root@6.28.12
+MY_OS_REL=$(cat /etc/os-release | grep ^NAME | sed -e 's/NAME=//g' -e 's/"//g')
 
-    export ROOT_INCLUDE_PATH=/cvmfs/larsoft.opensciencegrid.org/spack-packages/opt/spack/linux-almalinux9-x86_64_v2/gcc-12.2.0/root-6.28.12-sfwfmqorvxttrxgfrfhoq5kplou2pddd/include/:$ROOT_INCLUDE_PATH
-    export LD_LIBRARY_PATH=$LD_LIBRARY_PATH:$E4Track_LIB_PATH:/cvmfs/larsoft.opensciencegrid.org/spack-packages/opt/spack/linux-almalinux9-x86_64_v2/gcc-12.2.0/root-6.28.12-sfwfmqorvxttrxgfrfhoq5kplou2pddd/lib/
+if [ "$MY_OS_REL" = "AlmaLinux" ]; then
+  source /cvmfs/larsoft.opensciencegrid.org/spack-v0.22.0-fermi/setup-env.sh
+  spack load root@6.28.12 arch=linux-almalinux9-x86_64_v3
+  spack load gcc@12.2.0
+elif [ "$MY_OS_REL" = "Scientific Linux" ]; then
+
+  #Check if PRODUCTS is undefined -- if so, set up relevant ups area
+  if [[ -z $PRODUCTS ]]; then
+    if [[ $HOSTNAME == "dunegpvm"* ]]; then
+      echo DUNE
+      source /cvmfs/dune.opensciencegrid.org/products/dune/setup_dune.sh
+    elif [[ $HOSTNAME == "uboonegpvm"* ]]; then
+      echo "uboone"
+      source /cvmfs/uboone.opensciencegrid.org/products/setup_uboone.sh
+    else
+      echo "Warning: Unrecognized hostname $HOSTNAME"
+    fi
+  fi
+
+  setup root v6_28_12 -q e26:p3915:prof 
+  setup cmake v3_27_4
+else
+  echo "WARNING: Unrecognized OS name \"${MY_OS_REL}\""
+  echo "Unable to automatically set up ROOT"
 fi
+
+export ROOT_INCLUDE_PATH=`root-config --incdir`:$ROOT_INCLUDE_PATH
+export LD_LIBRARY_PATH=$E4Track_LIB_PATH:`root-config --libdir`:$LD_LIBRARY_PATH

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -21,6 +21,7 @@ set_target_properties(E4Track PROPERTIES
 target_link_libraries(E4Track
 PUBLIC
   ${ROOT_LIBRARIES}
+  ROOT::MathMore
 )
 
 install(TARGETS E4Track


### PR DESCRIPTION
…SL7 it looks for a ups products area being defined and sets one up if not. That is based on the hostname (currently dunegpvm or uboonegvm -- can extend i.e. to sbnd gvms but idk their name

Also I moved run_test.C to an app directory so it gets built. There were linkage issues when running it as a root macro in SL7 